### PR TITLE
Add emotion-reactive visual themes

### DIFF
--- a/script.js
+++ b/script.js
@@ -42,6 +42,8 @@ const MAZE = {
 
 let playerPath = [];
 let emotions = { fear: 0, hope: 0, anger: 0, curiosity: 0 };
+let currentEmotionClass = '';
+let debugPanel = null;
 
 function applyEffects(effects) {
   if (!effects) return;
@@ -60,6 +62,25 @@ function dominantEmotion() {
     }
   }
   return top;
+}
+
+function updateBodyEmotion() {
+  const dom = dominantEmotion();
+  const cls = dom ? `emotion-${dom}` : '';
+  if (cls !== currentEmotionClass) {
+    if (currentEmotionClass) {
+      document.body.classList.remove(currentEmotionClass);
+    }
+    if (cls) {
+      document.body.classList.add(cls);
+    }
+    currentEmotionClass = cls;
+  }
+  if (debugPanel) {
+    debugPanel.textContent = Object.entries(emotions)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join(' | ');
+  }
 }
 
 function showRoom(roomId) {
@@ -81,6 +102,7 @@ function showRoom(roomId) {
     btn.addEventListener('click', () => {
       playerPath.push(roomId);
       applyEffects(choice.effects);
+      updateBodyEmotion();
       const next = choice.next;
       if (!MAZE[next] || MAZE[next].choices.length === 0) {
         playerPath.push(next);
@@ -97,10 +119,38 @@ function showRoom(roomId) {
 
   maze.appendChild(room);
   requestAnimationFrame(() => room.classList.add('visible'));
+  updateBodyEmotion();
 }
 
 document.addEventListener('DOMContentLoaded', () => {
   playerPath = [];
   emotions = { fear: 0, hope: 0, anger: 0, curiosity: 0 };
+  debugPanel = document.createElement('div');
+  debugPanel.id = 'debug';
+  debugPanel.style.position = 'fixed';
+  debugPanel.style.bottom = '10px';
+  debugPanel.style.right = '10px';
+  debugPanel.style.padding = '4px 6px';
+  debugPanel.style.background = 'rgba(0,0,0,0.6)';
+  debugPanel.style.color = '#fff';
+  debugPanel.style.fontSize = '0.8em';
+  debugPanel.style.display = 'none';
+  document.body.appendChild(debugPanel);
+
+  const toggle = document.createElement('button');
+  toggle.id = 'debug-toggle';
+  toggle.textContent = 'Debug';
+  toggle.style.position = 'fixed';
+  toggle.style.bottom = '10px';
+  toggle.style.left = '10px';
+  toggle.style.fontSize = '0.8em';
+  toggle.addEventListener('click', () => {
+    debugPanel.style.display = debugPanel.style.display === 'none' ? 'block' : 'none';
+    updateBodyEmotion();
+  });
+  document.body.appendChild(toggle);
+
   showRoom('start');
+  updateBodyEmotion();
 });
+

--- a/style.css
+++ b/style.css
@@ -6,7 +6,8 @@ body {
   align-items: center;
   background: #111;
   color: #eee;
-  font-family: Arial, sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, sans-serif;
+  transition: background 1s ease, color 1s ease, letter-spacing 1s ease;
 }
 
 #maze {
@@ -38,18 +39,51 @@ button:hover {
   background: #555;
 }
 
-body.fear {
-  background: #300;
+.emotion-fear {
+  background: radial-gradient(circle at 50% 50%, #210033, #000);
+  color: #d0caff;
+  letter-spacing: -0.02em;
+  animation: fearGlow 4s ease-in-out infinite;
 }
 
-body.hope {
-  background: #031;
+@keyframes fearGlow {
+  0%, 100% { text-shadow: 0 0 5px #45006a; }
+  50% { text-shadow: 0 0 20px #7b2fbd; }
 }
 
-body.anger {
-  background: #600;
+.emotion-hope {
+  background: radial-gradient(circle at top, #fff9c4, #fffbe6);
+  color: #222;
+  letter-spacing: 0.05em;
+  font-weight: 600;
 }
 
-body.curiosity {
-  background: #013;
+.emotion-anger {
+  background: linear-gradient(45deg, #550000, #9e1305);
+  color: #ffd0d0;
+  animation: angerShake 0.3s ease-in-out infinite alternate;
 }
+
+@keyframes angerShake {
+  from { transform: translateX(-2px); }
+  to { transform: translateX(2px); }
+}
+
+.emotion-curiosity {
+  background: linear-gradient(135deg, #00334f, #007a6e);
+  background-size: 400% 400%;
+  color: #bff;
+  animation: curiosityShift 8s ease infinite;
+}
+
+@keyframes curiosityShift {
+  0%, 100% { background-position: 0% 0%; }
+  50% { background-position: 100% 100%; }
+}
+
+.emotion-sadness {
+  background: linear-gradient(#223, #456);
+  color: #cfd8e6;
+  letter-spacing: 0.02em;
+}
+

--- a/summary.html
+++ b/summary.html
@@ -13,7 +13,7 @@
     const emotions = JSON.parse(localStorage.getItem('emotions') || '{}');
     const dominant = localStorage.getItem('dominantEmotion');
     if (dominant) {
-      document.body.classList.add(dominant);
+      document.body.classList.add(`emotion-${dominant}`);
       const msg = document.createElement('p');
       msg.textContent = `You journeyed with ${dominant} as your guide.`;
       document.getElementById('summary').appendChild(msg);


### PR DESCRIPTION
## Summary
- trigger new `updateBodyEmotion` after each choice to update the `<body>` class
- add optional debug panel showing current emotion values
- create CSS themes for `emotion-fear`, `emotion-hope`, `emotion-anger`, `emotion-curiosity`, and `emotion-sadness`
- theme the summary page using the dominant emotion

## Testing
- `node -e "require('./script.js')"` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68489387fab0833182ee38e3e2e3e315