### PR TITLE
Add conditional choice gating

### DIFF
--- a/style.css
+++ b/style.css
@@ -128,3 +128,8 @@ button:hover {
   to { opacity: 1; }
 }
 
+/* highlight gated choices when debug is active */
+.debug-mode button[data-gated="true"] {
+  outline: 1px dashed orange;
+}
+

--- a/summary.html
+++ b/summary.html
@@ -26,6 +26,13 @@
       wrap.textContent = 'You remembered: ' + flashbacks.map(id => labels[id] || id).join(', ') + '.';
       document.getElementById('summary').appendChild(wrap);
     }
+
+    const conditionals = JSON.parse(localStorage.getItem('conditionalChoices') || '[]');
+    if (conditionals.length) {
+      const c = document.createElement('p');
+      c.textContent = 'Hidden paths unlocked: ' + conditionals.join(', ') + '.';
+      document.getElementById('summary').appendChild(c);
+    }
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- extend MAZE data to allow choice `condition` functions
- filter choices in `showRoom` according to current emotions and flashbacks
- record gated choices for the summary page
- add rooms `hidden` and `ending_d` to demo conditional paths
- add debug mode style to highlight gated choices
- display unlocked hidden paths on the summary screen

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_684898254ce883319557787a2d3cc058