### PR TITLE
Add epilogue selection system

### DIFF
--- a/maze.html
+++ b/maze.html
@@ -19,5 +19,12 @@
     <button id="self-map-close">Close</button>
   </div>
   <script src="script.js"></script>
+  <script>
+    window.addEventListener('beforeunload', () => {
+      if (typeof saveGameState === 'function') {
+        saveGameState();
+      }
+    });
+  </script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -209,3 +209,61 @@ button:hover {
   padding: 20px;
 }
 
+.epilogue {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  padding: 20px;
+  opacity: 0;
+  transition: opacity 1s ease;
+  z-index: 3000;
+}
+
+.epilogue.show {
+  opacity: 1;
+}
+
+.epilogue button {
+  margin-top: 20px;
+}
+
+.epilogue--fear {
+  background: radial-gradient(circle at 50% 50%, #210033, #000);
+  color: #d0caff;
+  letter-spacing: -0.02em;
+  animation: fearGlow 4s ease-in-out infinite;
+}
+
+.epilogue--hope {
+  background: radial-gradient(circle at top, #fff9c4, #fffbe6);
+  color: #222;
+  letter-spacing: 0.05em;
+  font-weight: 600;
+}
+
+.epilogue--anger {
+  background: linear-gradient(45deg, #550000, #9e1305);
+  color: #ffd0d0;
+  animation: angerShake 0.3s ease-in-out infinite alternate;
+}
+
+.epilogue--curiosity {
+  background: linear-gradient(135deg, #00334f, #007a6e);
+  background-size: 400% 400%;
+  color: #bff;
+  animation: curiosityShift 8s ease infinite;
+}
+
+.epilogue--sadness {
+  background: linear-gradient(#223, #456);
+  color: #cfd8e6;
+  letter-spacing: 0.02em;
+}
+

--- a/summary.html
+++ b/summary.html
@@ -9,9 +9,11 @@
   <div id="summary">
     <p>Thanks for playing. Your journey has been recorded.</p>
   </div>
+  <div id="epilogue" class="epilogue"></div>
+  <script src="script.js"></script>
   <script>
     const emotions = JSON.parse(localStorage.getItem('emotions') || '{}');
-    const dominant = localStorage.getItem('dominantEmotion');
+    const dominant = getDominantEmotion(emotions);
     if (dominant) {
       document.body.classList.add(`emotion-${dominant}`);
       const msg = document.createElement('p');
@@ -57,6 +59,18 @@
       });
       document.body.appendChild(wrap);
     }
+
+    const state = { emotions, triggeredFlashbacks: flashbacks, playerJourney: journey };
+    state.dominantEmotion = dominant;
+    const ending = getFinalEnding(state);
+    const ep = document.getElementById('epilogue');
+    ep.classList.add(`epilogue--${dominant}`);
+    ep.innerHTML = `<p>${ending.text}</p>`;
+    const replay = document.createElement('button');
+    replay.textContent = 'Re-enter the Maze';
+    replay.addEventListener('click', () => { localStorage.clear(); window.location.href = 'maze.html'; });
+    ep.appendChild(replay);
+    setTimeout(() => ep.classList.add('show'), 300);
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- implement `endings` array and helper functions in **script.js**
- export helpers for use on summary page and save game state consistently
- display chosen ending in summary with new full screen epilogue block
- style epilogues by dominant emotion
- ensure maze saves state on page unload

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68489e702eec83319a354e2b82500bdc