### PR TITLE
Add manipulation encounters and summary tracking

### DIFF
--- a/maze.html
+++ b/maze.html
@@ -11,6 +11,10 @@
     <div class="flashback-text" id="flashback-text"></div>
     <button id="flashback-ok">Continue</button>
   </div>
+  <div id="manipulation-info">
+    <div class="manipulation-text" id="manipulation-text"></div>
+    <button id="manipulation-ok">Continue</button>
+  </div>
   <div id="null-dialog"></div>
   <button id="self-map-btn" class="self-map-button">Self Map</button>
   <div id="self-map-overlay" class="self-map-overlay">

--- a/style.css
+++ b/style.css
@@ -96,6 +96,45 @@ button:hover {
   filter: blur(4px);
 }
 
+/* Manipulation visual mode */
+.manipulation-mode {
+  font-style: italic;
+  animation: manipulationPulse 0.6s infinite alternate;
+}
+
+.manipulation-mode #maze {
+  filter: contrast(1.3) hue-rotate(10deg);
+}
+
+@keyframes manipulationPulse {
+  from { letter-spacing: 0; }
+  to { letter-spacing: 2px; }
+}
+
+#manipulation-info {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.8);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  text-align: center;
+  color: #fff;
+  z-index: 1200;
+}
+
+#manipulation-info.show {
+  display: flex;
+}
+
+.resist {
+  border: 1px solid #f55;
+}
+
 #flashback-box {
   position: fixed;
   top: 0;

--- a/summary.html
+++ b/summary.html
@@ -43,6 +43,16 @@
       document.getElementById('summary').appendChild(p);
     }
 
+    const manip = JSON.parse(localStorage.getItem('manipulationLog') || '[]');
+    if (manip.length) {
+      const spotted = manip.filter(m => m.spotted).length;
+      const missed = manip.length - spotted;
+      const patterns = [...new Set(manip.map(m => m.type))].join(', ');
+      const p = document.createElement('p');
+      p.textContent = `Manipulations spotted: ${spotted}/${manip.length}. Missed: ${missed}. Patterns: ${patterns}.`;
+      document.getElementById('summary').appendChild(p);
+    }
+
     const journey = JSON.parse(localStorage.getItem('playerJourney') || '[]');
     if (journey.length) {
       const wrap = document.createElement('div');


### PR DESCRIPTION
## Summary
- implement `manipulationEncounters` with example `guilt_pit`
- show manipulation events with warped style and resistance option
- new `.manipulation-mode` and overlay styling
- track manipulation results and report them on summary screen

## Testing
- `node -e "new Function(require('fs').readFileSync('script.js','utf8'))"`

------
https://chatgpt.com/codex/tasks/task_e_6848a08241d08331b9aa8839e4c24def