### PR TITLE
Add manipulation room system with guilt trip encounter

### DIFF
--- a/style.css
+++ b/style.css
@@ -99,11 +99,15 @@ button:hover {
 /* Manipulation visual mode */
 .manipulation-mode {
   font-style: italic;
+  background: #000;
+  letter-spacing: 0.05em;
+  text-shadow: 0 0 6px #f00;
+  transform: scale(1.02);
   animation: manipulationPulse 0.6s infinite alternate;
 }
 
 .manipulation-mode #maze {
-  filter: contrast(1.3) hue-rotate(10deg);
+  filter: contrast(1.5) hue-rotate(-20deg);
 }
 
 @keyframes manipulationPulse {

--- a/summary.html
+++ b/summary.html
@@ -45,11 +45,11 @@
 
     const manip = JSON.parse(localStorage.getItem('manipulationLog') || '[]');
     if (manip.length) {
-      const spotted = manip.filter(m => m.spotted).length;
-      const missed = manip.length - spotted;
-      const patterns = [...new Set(manip.map(m => m.type))].join(', ');
+      const resisted = manip.filter(m => m.outcome === 'resisted').length;
+      const submitted = manip.length - resisted;
+      const tactics = [...new Set(manip.map(m => m.tactic))].join(', ');
       const p = document.createElement('p');
-      p.textContent = `Manipulations spotted: ${spotted}/${manip.length}. Missed: ${missed}. Patterns: ${patterns}.`;
+      p.textContent = `You resisted ${resisted}/${manip.length} manipulations. Fell for: ${submitted}. Tactics encountered: ${tactics}.`;
       document.getElementById('summary').appendChild(p);
     }
 


### PR DESCRIPTION
## Summary
- implement `manipulationRooms` and a new `guilt_chamber` manipulation scene
- log manipulation outcomes (`resisted` or `submitted`)
- render manipulation rooms with `renderManipulationRoom`
- introduce darker, distorted `.manipulation-mode` styles
- display manipulation results on summary page

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6848a2905dc48331b9ec64a502cab783