### PR TITLE
Add Pattern Sense skill

### DIFF
--- a/maze.html
+++ b/maze.html
@@ -16,6 +16,8 @@
     <button id="manipulation-ok">Continue</button>
   </div>
   <div id="null-dialog"></div>
+  <div id="pattern-warning"></div>
+  <div id="skill-unlock"></div>
   <button id="self-map-btn" class="self-map-button">Self Map</button>
   <div id="self-map-overlay" class="self-map-overlay">
     <h2>Self Map</h2>

--- a/style.css
+++ b/style.css
@@ -201,6 +201,27 @@ button:hover {
   animation: nullFade 0.4s ease;
 }
 
+#pattern-warning, #skill-unlock {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0,0,0,0.8);
+  color: #fff;
+  text-align: center;
+  font-size: 1.2em;
+  z-index: 1600;
+}
+
+#pattern-warning.show, #skill-unlock.show {
+  display: flex;
+  animation: nullFade 0.4s ease;
+}
+
 @keyframes nullFade {
   from { opacity: 0; }
   to { opacity: 1; }

--- a/summary.html
+++ b/summary.html
@@ -52,6 +52,12 @@
       p.textContent = `You resisted ${resisted}/${manip.length} manipulations. Fell for: ${submitted}. Tactics encountered: ${tactics}.`;
       document.getElementById('summary').appendChild(p);
     }
+    const skills = JSON.parse(localStorage.getItem("skills") || "{}");
+    if (skills.patternSense) {
+      const sp = document.createElement("p");
+      sp.textContent = "Skill unlocked: Pattern Sense";
+      document.getElementById("summary").appendChild(sp);
+    }
 
     const journey = JSON.parse(localStorage.getItem('playerJourney') || '[]');
     if (journey.length) {


### PR DESCRIPTION
## Summary
- introduce Pattern Sense overlay and unlock notifications
- warn about upcoming manipulations when the skill is active
- grant the skill when resisting a manipulation
- persist skills and show them on the summary screen

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_6848a6ef6ac0833195d1bc3c7336a2a0