### PR TITLE
Add Emotional Anchor ability

### DIFF
--- a/style.css
+++ b/style.css
@@ -139,6 +139,10 @@ button:hover {
   border: 1px solid #f55;
 }
 
+.anchor {
+  border: 1px solid #8af;
+}
+
 #flashback-box {
   position: fixed;
   top: 0;

--- a/summary.html
+++ b/summary.html
@@ -58,6 +58,11 @@
       sp.textContent = "Skill unlocked: Pattern Sense";
       document.getElementById("summary").appendChild(sp);
     }
+    if (skills.anchorUnlocked) {
+      const ap = document.createElement("p");
+      ap.textContent = "Skill unlocked: Emotional Anchor" + (skills.anchor === 0 ? " (used)" : "");
+      document.getElementById("summary").appendChild(ap);
+    }
 
     const journey = JSON.parse(localStorage.getItem('playerJourney') || '[]');
     if (journey.length) {


### PR DESCRIPTION
## Summary
- add Emotional Anchor skill data and unlocking logic
- allow manipulation encounters to be bypassed by spending an Anchor use
- show anchor skill in the summary screen
- style anchor buttons

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_6848ae935f508331bb223c000d7d69a1