### PR TITLE
Add skill tracking interface

### DIFF
--- a/maze.html
+++ b/maze.html
@@ -19,10 +19,16 @@
   <div id="pattern-warning"></div>
   <div id="skill-unlock"></div>
   <button id="self-map-btn" class="self-map-button">Self Map</button>
+  <button id="skills-btn" class="skills-button">Skills</button>
   <div id="self-map-overlay" class="self-map-overlay">
     <h2>Self Map</h2>
     <div id="self-map-content"></div>
     <button id="self-map-close">Close</button>
+  </div>
+  <div id="skills-overlay" class="skills-overlay">
+    <h2>Skills</h2>
+    <div id="skills-content"></div>
+    <button id="skills-close">Close</button>
   </div>
   <script src="script.js"></script>
   <script>

--- a/script.js
+++ b/script.js
@@ -238,7 +238,13 @@ let playerPath = [];
 let playerJourney = [];
 let emotions = { fear: 0, hope: 0, anger: 0, curiosity: 0 };
 let currentEmotionClass = '';
-let skills = { patternSense: false, anchor: 0, anchorUnlocked: false };
+let skills = {
+  patternSense: false,
+  patternSenseUses: 0,
+  anchor: 0,
+  anchorUnlocked: false,
+  anchorUses: 0
+};
 let debugPanel = null;
 
 function applyEffects(effects) {
@@ -317,6 +323,9 @@ function maybeTriggerNullDialog() {
 }
 function showPatternWarning(text, cb) {
   const box = document.getElementById("pattern-warning");
+  if (skills.patternSense) {
+    skills.patternSenseUses = (skills.patternSenseUses || 0) + 1;
+  }
   if (!box) { if (cb) cb(); return; }
   box.textContent = text;
   box.classList.add("show");
@@ -425,6 +434,41 @@ function closeSelfMap() {
   document.getElementById('self-map-overlay').classList.remove('show');
 }
 
+function openSkills() {
+  const overlay = document.getElementById('skills-overlay');
+  const list = document.getElementById('skills-content');
+  list.innerHTML = '';
+  const entries = [];
+  entries.push({
+    unlocked: skills.patternSense,
+    name: 'Pattern Sense',
+    uses: skills.patternSenseUses || 0,
+    desc: 'Recognize manipulation tactics before they unfold.'
+  });
+  entries.push({
+    unlocked: skills.anchorUnlocked,
+    name: 'Emotional Anchor',
+    uses: skills.anchorUses || 0,
+    desc: 'Ground yourself in self-trust to resist manipulation.'
+  });
+  entries.forEach(e => {
+    const div = document.createElement('div');
+    div.className = 'self-map-entry';
+    const title = document.createElement('strong');
+    title.textContent = e.name + (e.unlocked ? '' : ' (Locked)');
+    div.appendChild(title);
+    const info = document.createElement('div');
+    info.textContent = e.desc + (e.unlocked ? ` - Used ${e.uses} times` : '');
+    div.appendChild(info);
+    list.appendChild(div);
+  });
+  overlay.classList.add('show');
+}
+
+function closeSkills() {
+  document.getElementById('skills-overlay').classList.remove('show');
+}
+
 function showManipulationInfo(text, cb) {
   const box = document.getElementById('manipulation-info');
   const txt = document.getElementById('manipulation-text');
@@ -490,6 +534,7 @@ function showManipulation(id, cb) {
     a.classList.add('anchor');
     a.addEventListener('click', () => {
       skills.anchor -= 1;
+      skills.anchorUses = (skills.anchorUses || 0) + 1;
       manipulationLog.push({ room: event.id, tactic: event.type, outcome: 'anchored' });
       document.body.classList.remove('manipulation-mode');
       showSkillUnlock('Emotional Anchor Used');
@@ -544,6 +589,7 @@ function renderManipulationRoom(room) {
     a.classList.add('anchor');
     a.addEventListener('click', () => {
       skills.anchor -= 1;
+      skills.anchorUses = (skills.anchorUses || 0) + 1;
       manipulationLog.push({ room: room.id, tactic: room.tactic, outcome: 'anchored' });
       document.body.classList.remove('manipulation-mode');
       playerPath.push(room.id);
@@ -639,7 +685,13 @@ function renderRoom(roomId) {
     playerJourney = [];
     emotions = { fear: 0, hope: 0, anger: 0, curiosity: 0 };
   triggeredFlashbacks = [];
-    skills = { patternSense: false, anchor: 0, anchorUnlocked: false };
+    skills = {
+      patternSense: false,
+      patternSenseUses: 0,
+      anchor: 0,
+      anchorUnlocked: false,
+      anchorUses: 0
+    };
   manipulationLog = [];
   triggeredManipulations = [];
   conditionalChoicesTaken = [];
@@ -680,6 +732,13 @@ function renderRoom(roomId) {
     if (mapBtn && mapClose) {
       mapBtn.addEventListener('click', openSelfMap);
       mapClose.addEventListener('click', closeSelfMap);
+    }
+
+    const skillsBtn = document.getElementById('skills-btn');
+    const skillsClose = document.getElementById('skills-close');
+    if (skillsBtn && skillsClose) {
+      skillsBtn.addEventListener('click', openSkills);
+      skillsClose.addEventListener('click', closeSkills);
     }
 
   renderRoom('start');

--- a/style.css
+++ b/style.css
@@ -238,6 +238,13 @@ button:hover {
   font-size: 0.8em;
 }
 
+.skills-button {
+  position: fixed;
+  top: 10px;
+  right: 80px;
+  font-size: 0.8em;
+}
+
 .self-map-overlay {
   position: fixed;
   top: 0;
@@ -251,6 +258,25 @@ button:hover {
   padding: 20px;
   overflow-y: auto;
   z-index: 2000;
+}
+
+.skills-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.95);
+  color: #fff;
+  display: none;
+  flex-direction: column;
+  padding: 20px;
+  overflow-y: auto;
+  z-index: 2100;
+}
+
+.skills-overlay.show {
+  display: flex;
 }
 
 .self-map-overlay.show {

--- a/summary.html
+++ b/summary.html
@@ -55,12 +55,12 @@
     const skills = JSON.parse(localStorage.getItem("skills") || "{}");
     if (skills.patternSense) {
       const sp = document.createElement("p");
-      sp.textContent = "Skill unlocked: Pattern Sense";
+      sp.textContent = `Skill unlocked: Pattern Sense - used ${skills.patternSenseUses || 0} times`;
       document.getElementById("summary").appendChild(sp);
     }
     if (skills.anchorUnlocked) {
       const ap = document.createElement("p");
-      ap.textContent = "Skill unlocked: Emotional Anchor" + (skills.anchor === 0 ? " (used)" : "");
+      ap.textContent = `Skill unlocked: Emotional Anchor - used ${skills.anchorUses || 0} times`;
       document.getElementById("summary").appendChild(ap);
     }
 


### PR DESCRIPTION
## Summary
- add Skills screen overlay and button
- style the overlay and button
- track Pattern Sense and Emotional Anchor usage
- show usage counts in summary page

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6848b09c58f48331918cd9b9b2b2050f