### PR TITLE
Add favicon and mobile meta tags

### DIFF
--- a/favicon.svg
+++ b/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="8" ry="8" fill="#111"/>
+  <path d="M16 16h32v32H32V32H16z" stroke="#fff" stroke-width="4" fill="none"/>
+</svg>

--- a/maze.html
+++ b/maze.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Mirror Maze</title>
   <link rel="stylesheet" href="style.css">
 </head>

--- a/style.css
+++ b/style.css
@@ -1,6 +1,6 @@
 body {
   margin: 0;
-  height: 100vh;
+  min-height: 100vh;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/summary.html
+++ b/summary.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Mirror Maze - Summary</title>
   <link rel="stylesheet" href="style.css">
 </head>


### PR DESCRIPTION
## Summary
- embed a simple maze icon in `favicon.svg`
- add viewport meta tag to `maze.html` and `summary.html`
- use `min-height: 100vh` for body to better support mobile screens

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_6848b5e0048c8331994ea9f837a05596