### PR TITLE
Add semantic markup and keyboard controls

### DIFF
--- a/flashbacks.js
+++ b/flashbacks.js
@@ -5,12 +5,14 @@ function showFlashback(text) {
   txt.textContent = text;
   box.classList.add('show');
   document.body.classList.add('flashback-mode');
+  document.addEventListener('keydown', handleFlashbackKey);
   lastFocusedElement = document.activeElement;
   btn.focus();
   const handler = () => {
     box.classList.remove('show');
     document.body.classList.remove('flashback-mode');
     btn.removeEventListener('click', handler);
+    document.removeEventListener('keydown', handleFlashbackKey);
     if (lastFocusedElement) lastFocusedElement.focus();
   };
   btn.addEventListener('click', handler);

--- a/game.js
+++ b/game.js
@@ -1,3 +1,19 @@
+function handleChoiceNavigation(e) {
+  const keys = ['ArrowUp', 'ArrowLeft', 'ArrowDown', 'ArrowRight'];
+  if (!keys.includes(e.key)) return;
+  const buttons = Array.from(e.currentTarget.querySelectorAll('button'));
+  const idx = buttons.indexOf(document.activeElement);
+  if (idx === -1) return;
+  e.preventDefault();
+  let next = idx;
+  if (e.key === 'ArrowUp' || e.key === 'ArrowLeft') {
+    next = idx > 0 ? idx - 1 : buttons.length - 1;
+  } else {
+    next = idx < buttons.length - 1 ? idx + 1 : 0;
+  }
+  buttons[next].focus();
+}
+
 function renderRoom(roomId) {
   currentRoom = roomId;
   const roomData = MAZE[roomId] || manipulationRooms[roomId];
@@ -73,6 +89,9 @@ function renderRoom(roomId) {
 
   maze.appendChild(room);
   requestAnimationFrame(() => room.classList.add('visible'));
+  const firstBtn = room.querySelector('button');
+  if (firstBtn) firstBtn.focus();
+  room.addEventListener('keydown', handleChoiceNavigation);
   updateBodyEmotion();
   checkForFlashbacks();
   maybeTriggerNullDialog();

--- a/index.html
+++ b/index.html
@@ -7,10 +7,12 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <div id="landing">
-    <h1>Mirror Maze</h1>
-    <p>Navigate a shifting labyrinth where every choice shapes your fate.</p>
-    <a href="maze.html" class="start-link">Enter the Maze</a>
-  </div>
+  <main id="landing" role="main">
+    <section>
+      <h1>Mirror Maze</h1>
+      <p>Navigate a shifting labyrinth where every choice shapes your fate.</p>
+      <a href="maze.html" class="start-link">Enter the Maze</a>
+    </section>
+  </main>
 </body>
 </html>

--- a/manipulations.js
+++ b/manipulations.js
@@ -9,11 +9,13 @@ function showManipulationInfo(text, cb) {
   }
   txt.textContent = text;
   box.classList.add('show');
+  document.addEventListener('keydown', handleManipInfoKey);
   lastFocusedElement = document.activeElement;
   btn.focus();
   const handler = () => {
     box.classList.remove('show');
     btn.removeEventListener('click', handler);
+    document.removeEventListener('keydown', handleManipInfoKey);
     if (lastFocusedElement) lastFocusedElement.focus();
     cb();
   };
@@ -79,6 +81,9 @@ function showManipulation(id, cb) {
     });
     maze.appendChild(a);
   }
+  const firstBtn = maze.querySelector('button');
+  if (firstBtn) firstBtn.focus();
+  maze.addEventListener('keydown', handleChoiceNavigation);
 }
 
 function renderManipulationRoom(room) {
@@ -141,4 +146,7 @@ function renderManipulationRoom(room) {
     });
     maze.appendChild(a);
   }
+  const firstBtn = maze.querySelector('button');
+  if (firstBtn) firstBtn.focus();
+  maze.addEventListener('keydown', handleChoiceNavigation);
 }

--- a/maze.html
+++ b/maze.html
@@ -8,30 +8,30 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <div id="maze"></div>
-  <div id="flashback-box" role="dialog" aria-modal="true" aria-labelledby="flashback-text">
+  <main id="maze" role="main" tabindex="-1" aria-live="polite"></main>
+  <section id="flashback-box" role="dialog" aria-modal="true" aria-labelledby="flashback-text" tabindex="-1">
     <div class="flashback-text" id="flashback-text"></div>
     <button id="flashback-ok" aria-label="Close flashback">Continue</button>
-  </div>
-  <div id="manipulation-info" role="dialog" aria-modal="true" aria-labelledby="manipulation-text">
+  </section>
+  <section id="manipulation-info" role="dialog" aria-modal="true" aria-labelledby="manipulation-text" tabindex="-1">
     <div class="manipulation-text" id="manipulation-text"></div>
     <button id="manipulation-ok" aria-label="Close manipulation info">Continue</button>
-  </div>
+  </section>
   <div id="null-dialog"></div>
   <div id="pattern-warning"></div>
   <div id="skill-unlock"></div>
   <button id="self-map-btn" class="self-map-button" aria-label="Open self map">Self Map</button>
   <button id="skills-btn" class="skills-button" aria-label="Open skills">Skills</button>
-  <div id="self-map-overlay" class="self-map-overlay" role="dialog" aria-modal="true" aria-labelledby="self-map-title" aria-hidden="true">
+  <section id="self-map-overlay" class="self-map-overlay" role="dialog" aria-modal="true" aria-labelledby="self-map-title" aria-hidden="true" tabindex="-1">
     <h2 id="self-map-title">Self Map</h2>
     <div id="self-map-content"></div>
     <button id="self-map-close" aria-label="Close self map">Close</button>
-  </div>
-  <div id="skills-overlay" class="skills-overlay" role="dialog" aria-modal="true" aria-labelledby="skills-title" aria-hidden="true">
+  </section>
+  <section id="skills-overlay" class="skills-overlay" role="dialog" aria-modal="true" aria-labelledby="skills-title" aria-hidden="true" tabindex="-1">
     <h2 id="skills-title">Skills</h2>
     <div id="skills-content"></div>
     <button id="skills-close" aria-label="Close skills">Close</button>
-  </div>
+  </section>
   <script src="maze-data.js"></script>
   <script src="state.js"></script>
   <script src="flashbacks.js"></script>

--- a/state.js
+++ b/state.js
@@ -23,6 +23,36 @@ let skills = {
 let mazeCorruption = 0;
 let debugPanel = null;
 
+function handleSelfMapKey(e) {
+  if (e.key === 'Escape') {
+    e.preventDefault();
+    closeSelfMap();
+  }
+}
+
+function handleSkillsKey(e) {
+  if (e.key === 'Escape') {
+    e.preventDefault();
+    closeSkills();
+  }
+}
+
+function handleFlashbackKey(e) {
+  if (e.key === 'Escape') {
+    e.preventDefault();
+    const btn = document.getElementById('flashback-ok');
+    if (btn) btn.click();
+  }
+}
+
+function handleManipInfoKey(e) {
+  if (e.key === 'Escape') {
+    e.preventDefault();
+    const btn = document.getElementById('manipulation-ok');
+    if (btn) btn.click();
+  }
+}
+
 function applyEffects(effects) {
   if (!effects) return;
   for (const key in effects) {
@@ -161,12 +191,14 @@ function showFlashback(text) {
   txt.textContent = text;
   box.classList.add('show');
   document.body.classList.add('flashback-mode');
+  document.addEventListener('keydown', handleFlashbackKey);
   lastFocusedElement = document.activeElement;
   btn.focus();
   const handler = () => {
     box.classList.remove('show');
     document.body.classList.remove('flashback-mode');
     btn.removeEventListener('click', handler);
+    document.removeEventListener('keydown', handleFlashbackKey);
     if (lastFocusedElement) lastFocusedElement.focus();
   };
   btn.addEventListener('click', handler);
@@ -231,6 +263,7 @@ function openSelfMap() {
   });
   overlay.classList.add('show');
   overlay.setAttribute('aria-hidden', 'false');
+  document.addEventListener('keydown', handleSelfMapKey);
   lastFocusedElement = document.activeElement;
   const closeBtn = document.getElementById('self-map-close');
   if (closeBtn) closeBtn.focus();
@@ -240,6 +273,7 @@ function closeSelfMap() {
   const overlay = document.getElementById('self-map-overlay');
   overlay.classList.remove('show');
   overlay.setAttribute('aria-hidden', 'true');
+  document.removeEventListener('keydown', handleSelfMapKey);
   if (lastFocusedElement) lastFocusedElement.focus();
 }
 
@@ -273,6 +307,7 @@ function openSkills() {
   });
   overlay.classList.add('show');
   overlay.setAttribute('aria-hidden', 'false');
+  document.addEventListener('keydown', handleSkillsKey);
   lastFocusedElement = document.activeElement;
   const closeBtn = document.getElementById('skills-close');
   if (closeBtn) closeBtn.focus();
@@ -282,5 +317,6 @@ function closeSkills() {
   const overlay = document.getElementById('skills-overlay');
   overlay.classList.remove('show');
   overlay.setAttribute('aria-hidden', 'true');
+  document.removeEventListener('keydown', handleSkillsKey);
   if (lastFocusedElement) lastFocusedElement.focus();
 }

--- a/summary.html
+++ b/summary.html
@@ -8,10 +8,10 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <div id="summary">
+  <main id="summary" role="main">
     <p>Thanks for playing. Your journey has been recorded.</p>
-  </div>
-  <div id="epilogue" class="epilogue"></div>
+  </main>
+  <section id="epilogue" class="epilogue"></section>
   <script src="maze-data.js"></script>
   <script src="state.js"></script>
   <script src="flashbacks.js"></script>


### PR DESCRIPTION
## Summary
- use `<main>` and `<section>` for page structure
- make overlays focusable dialogs
- manage focus and ESC key closing for dialogs
- allow arrow-key navigation between choices
- focus first button when rooms or manipulations appear

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_6848c623b6248331a3cceb80364b90d0