### PR TITLE
Add run memory echoes

### DIFF
--- a/game.js
+++ b/game.js
@@ -113,6 +113,17 @@ function renderRoom(roomId) {
     lastNullRoom = -3;
     mazeCorruption = parseInt(localStorage.getItem('corruption') || '0');
     currentRoom = localStorage.getItem('currentRoom') || 'start';
+    runHistory = JSON.parse(localStorage.getItem('runHistory') || '[]');
+    localStorage.removeItem('runArchived');
+    if (runHistory.length) {
+      const memories = ['You\u2019ve been here before.'];
+      const last = runHistory[runHistory.length - 1] || {};
+      if (last.submitted) memories.push('Last time, you submitted.');
+      if (last.anchorUsed > 0) memories.push('The Anchor was used\u2026 and forgotten.');
+      memories.forEach(m => {
+        nullDialogs.push({ text: m, condition: () => !triggeredNullDialogs.includes(m) });
+      });
+    }
   const isDebug = ['localhost', '127.0.0.1'].includes(location.hostname) ||
     new URLSearchParams(location.search).has('debug');
 

--- a/state.js
+++ b/state.js
@@ -22,6 +22,7 @@ let skills = {
 };
 let mazeCorruption = 0;
 let debugPanel = null;
+let runHistory = [];
 
 function handleSelfMapKey(e) {
   if (e.key === 'Escape') {

--- a/summary.html
+++ b/summary.html
@@ -21,11 +21,15 @@
     function archiveCurrentRun() {
       if (localStorage.getItem('runArchived') === 'true') return;
       const history = JSON.parse(localStorage.getItem('runHistory') || '[]');
+      const manip = JSON.parse(localStorage.getItem('manipulationLog') || '[]');
+      const skills = JSON.parse(localStorage.getItem('skills') || '{}');
       const entry = {
         time: new Date().toISOString(),
         dominant: localStorage.getItem('dominantEmotion'),
         flashbacks: JSON.parse(localStorage.getItem('triggeredFlashbacks') || '[]'),
-        journey: JSON.parse(localStorage.getItem('playerJourney') || '[]')
+        journey: JSON.parse(localStorage.getItem('playerJourney') || '[]'),
+        submitted: manip.some(m => m.outcome === 'submitted'),
+        anchorUsed: skills.anchorUses || 0
       };
       history.push(entry);
       localStorage.setItem('runHistory', JSON.stringify(history));


### PR DESCRIPTION
## Summary
- store additional run info when archiving a session
- track run history across games and expose it in state
- surface eerie memories via random null dialogs

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6848caaafd2083318d870eee4d838c77