### PR TITLE
Harden game state handling

### DIFF
--- a/game.js
+++ b/game.js
@@ -15,9 +15,10 @@ function handleChoiceNavigation(e) {
 }
 
 function renderRoom(roomId) {
-  currentRoom = roomId;
+  if (!isValidRoomId(roomId)) return;
+  if (isEndingRoom(roomId)) return;
   const roomData = MAZE[roomId] || manipulationRooms[roomId];
-  if (!roomData) return;
+  currentRoom = roomId;
   if (roomData.manipulation && !triggeredManipulations.includes(roomData.manipulation)) {
     const run = () => {
       showManipulation(roomData.manipulation, () => {
@@ -98,22 +99,26 @@ function renderRoom(roomId) {
 }
 
   document.addEventListener('DOMContentLoaded', () => {
-    playerPath = JSON.parse(localStorage.getItem('playerPath') || '[]');
-    playerJourney = JSON.parse(localStorage.getItem('playerJourney') || '[]');
-    emotions = JSON.parse(
-      localStorage.getItem('emotions') ||
-        JSON.stringify({ fear: 0, hope: 0, anger: 0, curiosity: 0 })
-    );
-    triggeredFlashbacks = JSON.parse(localStorage.getItem('triggeredFlashbacks') || '[]');
-    skills = Object.assign(skills, JSON.parse(localStorage.getItem('skills') || '{}'));
-    manipulationLog = JSON.parse(localStorage.getItem('manipulationLog') || '[]');
+    playerPath = safeJsonParse('playerPath', []);
+    playerJourney = safeJsonParse('playerJourney', []);
+    emotions = safeJsonParse('emotions', { fear: 0, hope: 0, anger: 0, curiosity: 0 });
+    triggeredFlashbacks = safeJsonParse('triggeredFlashbacks', []);
+    skills = Object.assign(skills, safeJsonParse('skills', {}));
+    manipulationLog = safeJsonParse('manipulationLog', []);
     triggeredManipulations = [];
-    conditionalChoicesTaken = JSON.parse(localStorage.getItem('conditionalChoices') || '[]');
-    triggeredNullDialogs = JSON.parse(localStorage.getItem('nullDialogs') || '[]');
+    conditionalChoicesTaken = safeJsonParse('conditionalChoices', []);
+    triggeredNullDialogs = safeJsonParse('nullDialogs', []);
     lastNullRoom = -3;
     mazeCorruption = parseInt(localStorage.getItem('corruption') || '0');
     currentRoom = localStorage.getItem('currentRoom') || 'start';
-    runHistory = JSON.parse(localStorage.getItem('runHistory') || '[]');
+    if (!isValidRoomId(currentRoom) || isEndingRoom(currentRoom)) {
+      currentRoom = 'start';
+    }
+    if (!isValidRoomId('start') || isEndingRoom('start')) {
+      const fallback = Object.keys(MAZE).find(id => !isEndingRoom(id));
+      if (fallback) currentRoom = fallback;
+    }
+    runHistory = safeJsonParse('runHistory', []);
     localStorage.removeItem('runArchived');
     if (runHistory.length) {
       const memories = ['You\u2019ve been here before.'];

--- a/state.js
+++ b/state.js
@@ -24,6 +24,26 @@ let mazeCorruption = 0;
 let debugPanel = null;
 let runHistory = [];
 
+function safeJsonParse(key, fallback) {
+  const val = localStorage.getItem(key);
+  if (val === null || val === undefined) return fallback;
+  try {
+    return JSON.parse(val);
+  } catch (e) {
+    console.warn('Corrupted localStorage detected. Clearing data.');
+    localStorage.clear();
+    return fallback;
+  }
+}
+
+function isValidRoomId(id) {
+  return !!(MAZE[id] || manipulationRooms[id]);
+}
+
+function isEndingRoom(id) {
+  return MAZE[id] && Array.isArray(MAZE[id].choices) && MAZE[id].choices.length === 0;
+}
+
 function handleSelfMapKey(e) {
   if (e.key === 'Escape') {
     e.preventDefault();


### PR DESCRIPTION
## Summary
- validate room IDs and avoid loading invalid endings
- safely parse stored JSON and wipe corrupted storage
- guard against invalid start room or missing data

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6848ce2495408331b35d243524f00f1b