### PR TITLE
Implement memory distortion events

### DIFF
--- a/distortions.js
+++ b/distortions.js
@@ -1,0 +1,46 @@
+// Memory distortion events
+let triggeredDistortions = [];
+
+function handleDistortionKey(e) {
+  if (e.key === 'Enter' || e.key === ' ') {
+    const btn = document.getElementById('distortion-ok');
+    if (btn) btn.click();
+  }
+}
+
+function showDistortion(text, alterPrompt) {
+  const box = document.getElementById('distortion-box');
+  const txt = document.getElementById('distortion-text');
+  const btn = document.getElementById('distortion-ok');
+  if (!box || !txt || !btn) { return; }
+  txt.textContent = text;
+  box.classList.add('show');
+  document.body.classList.add('distortion-mode');
+  document.addEventListener('keydown', handleDistortionKey);
+  lastFocusedElement = document.activeElement;
+  btn.focus();
+  const handler = () => {
+    box.classList.remove('show');
+    document.body.classList.remove('distortion-mode');
+    btn.removeEventListener('click', handler);
+    document.removeEventListener('keydown', handleDistortionKey);
+    if (alterPrompt) {
+      const roomPara = document.querySelector('#maze .room p');
+      if (roomPara) roomPara.textContent = alterPrompt;
+    }
+    if (lastFocusedElement) lastFocusedElement.focus();
+  };
+  btn.addEventListener('click', handler);
+}
+
+function checkForDistortions() {
+  const state = { playerPath, emotions, triggeredFlashbacks };
+  for (const d of DISTORTIONS) {
+    if (!triggeredDistortions.includes(d.id) && d.condition(state)) {
+      triggeredDistortions.push(d.id);
+      showDistortion(d.text, d.alterPrompt);
+      increaseCorruption(1);
+      break;
+    }
+  }
+}

--- a/game.js
+++ b/game.js
@@ -96,6 +96,7 @@ function renderRoom(roomId) {
   updateBodyEmotion();
   checkForFlashbacks();
   maybeTriggerNullDialog();
+  checkForDistortions();
 }
 
   document.addEventListener('DOMContentLoaded', () => {
@@ -103,6 +104,7 @@ function renderRoom(roomId) {
     playerJourney = safeJsonParse('playerJourney', []);
     emotions = safeJsonParse('emotions', { fear: 0, hope: 0, anger: 0, curiosity: 0 });
     triggeredFlashbacks = safeJsonParse('triggeredFlashbacks', []);
+    triggeredDistortions = safeJsonParse('distortions', []);
     skills = Object.assign(skills, safeJsonParse('skills', {}));
     manipulationLog = safeJsonParse('manipulationLog', []);
     triggeredManipulations = [];

--- a/maze-data.js
+++ b/maze-data.js
@@ -223,3 +223,22 @@ const nullDialogs = [
   { text: "The mirror is not your ally.", condition: (s) => s.triggeredFlashbacks.includes('hallway') },
   { text: "You will remember this command." }
 ];
+
+const DISTORTIONS = [
+  {
+    id: 'false_escape',
+    condition: (s) => s.playerPath.length >= 3,
+    text: 'You remember stepping outside the maze already... yet here you stand.'
+  },
+  {
+    id: 'twisted_promise',
+    condition: (s) => s.triggeredFlashbacks.includes('promise') && s.emotions.fear >= 3,
+    text: 'A new memory surfaces: a vow to remain trapped forever. Did you really say that?'
+  },
+  {
+    id: 'room_shift',
+    condition: (s) => s.playerPath.includes('hidden') && s.playerPath.length > 4,
+    text: 'The walls ripple. For a heartbeat the corridor resembles a childhood bedroom.',
+    alterPrompt: 'This room shouldn\'t look so familiar. The comfort is unsettling.'
+  }
+];

--- a/maze.html
+++ b/maze.html
@@ -13,6 +13,10 @@
     <div class="flashback-text" id="flashback-text"></div>
     <button id="flashback-ok" aria-label="Close flashback">Continue</button>
   </section>
+  <section id="distortion-box" role="dialog" aria-modal="true" aria-labelledby="distortion-text" tabindex="-1">
+    <div class="distortion-text" id="distortion-text"></div>
+    <button id="distortion-ok" aria-label="Close distortion">Continue</button>
+  </section>
   <section id="manipulation-info" role="dialog" aria-modal="true" aria-labelledby="manipulation-text" tabindex="-1">
     <div class="manipulation-text" id="manipulation-text"></div>
     <button id="manipulation-ok" aria-label="Close manipulation info">Continue</button>
@@ -35,6 +39,7 @@
   <script src="maze-data.js"></script>
   <script src="state.js"></script>
   <script src="flashbacks.js"></script>
+  <script src="distortions.js"></script>
   <script src="manipulations.js"></script>
   <script src="game.js"></script>
   <script>

--- a/state.js
+++ b/state.js
@@ -1,4 +1,5 @@
 let triggeredFlashbacks = [];
+let triggeredDistortions = [];
 let manipulationLog = [];
 let triggeredManipulations = [];
 let triggeredNullDialogs = [];
@@ -252,6 +253,7 @@ function saveGameState() {
   localStorage.setItem('emotions', JSON.stringify(emotions));
   localStorage.setItem('dominantEmotion', dominantEmotion());
   localStorage.setItem('triggeredFlashbacks', JSON.stringify(triggeredFlashbacks));
+  localStorage.setItem('distortions', JSON.stringify(triggeredDistortions));
   localStorage.setItem('conditionalChoices', JSON.stringify(conditionalChoicesTaken));
   localStorage.setItem('nullDialogs', JSON.stringify(triggeredNullDialogs));
   localStorage.setItem('playerJourney', JSON.stringify(playerJourney));

--- a/style.css
+++ b/style.css
@@ -173,7 +173,47 @@ button:hover {
 @keyframes flashIn {
   from { opacity: 0; }
   to { opacity: 1; }
+/* Distortion visual mode */
+.distortion-mode {
+  filter: contrast(1.2) hue-rotate(30deg);
 }
+
+.distortion-mode #maze {
+  transform: skewX(1deg);
+}
+
+#distortion-box {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.8);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  text-align: center;
+  color: #fff;
+  z-index: 1050;
+}
+
+#distortion-box.show {
+  display: flex;
+}
+
+.distortion-text {
+  font-size: 1.1em;
+  margin-bottom: 20px;
+  opacity: 0;
+  animation: distortIn 0.8s forwards;
+}
+
+@keyframes distortIn {
+  from { opacity: 0; transform: skewX(3deg); }
+  to { opacity: 1; transform: skewX(0); }
+}
+
 
 /* highlight gated choices when debug is active */
 .debug-mode button[data-gated="true"] {

--- a/summary.html
+++ b/summary.html
@@ -15,6 +15,7 @@
   <script src="maze-data.js"></script>
   <script src="state.js"></script>
   <script src="flashbacks.js"></script>
+  <script src="distortions.js"></script>
   <script src="manipulations.js"></script>
   <script src="game.js"></script>
   <script>
@@ -27,6 +28,7 @@
         time: new Date().toISOString(),
         dominant: localStorage.getItem('dominantEmotion'),
         flashbacks: JSON.parse(localStorage.getItem('triggeredFlashbacks') || '[]'),
+        distortions: JSON.parse(localStorage.getItem('distortions') || '[]'),
         journey: JSON.parse(localStorage.getItem('playerJourney') || '[]'),
         submitted: manip.some(m => m.outcome === 'submitted'),
         anchorUsed: skills.anchorUses || 0
@@ -56,11 +58,17 @@
     }
 
     const flashbacks = JSON.parse(localStorage.getItem('triggeredFlashbacks') || '[]');
+    const distortions = JSON.parse(localStorage.getItem('distortions') || '[]');
     if (flashbacks.length) {
       const labels = { hallway: 'The Hallway', promise: 'The Promise' };
       const wrap = document.createElement('p');
       wrap.textContent = 'You remembered: ' + flashbacks.map(id => labels[id] || id).join(', ') + '.';
       document.getElementById('summary').appendChild(wrap);
+    }
+    if (distortions.length) {
+      const dp = document.createElement("p");
+      dp.textContent = "Distortions experienced: " + distortions.join(", ") + ".";
+      document.getElementById("summary").appendChild(dp);
     }
 
     const conditionals = JSON.parse(localStorage.getItem('conditionalChoices') || '[]');


### PR DESCRIPTION
## Summary
- add memory distortion system
- store triggered distortions in state
- include distortion overlay and styles
- log distortions on summary page
- define example distortions

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6848d0b558488331915e51d0c3e577f2