### PR TITLE
Add Truth Sense skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ The project is entirely static and does not require a build step. There are also
 
 Enjoy exploring the maze!
 
+## Skills
+
+As you progress, you may unlock special abilities:
+
+- **Pattern Sense** – notice manipulation tactics before they unfold.
+- **Emotional Anchor** – ground yourself in self-trust to resist control.
+- **Truth Sense** – automatically detect false memories and distorted rooms after surviving repeated loops.
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).

--- a/distortions.js
+++ b/distortions.js
@@ -38,8 +38,14 @@ function checkForDistortions() {
   for (const d of DISTORTIONS) {
     if (!triggeredDistortions.includes(d.id) && d.condition(state)) {
       triggeredDistortions.push(d.id);
-      showDistortion(d.text, d.alterPrompt);
-      increaseCorruption(1);
+      if (skills.truthSense) {
+        skills.truthSenseTriggers = (skills.truthSenseTriggers || 0) + 1;
+        showNullDialog('Truth Sense rejects a false memory.');
+      } else {
+        showDistortion(d.text, d.alterPrompt);
+        increaseCorruption(1);
+      }
+      maybeGrantTruthSense();
       break;
     }
   }

--- a/game.js
+++ b/game.js
@@ -131,6 +131,7 @@ function renderRoom(roomId) {
         nullDialogs.push({ text: m, condition: () => !triggeredNullDialogs.includes(m) });
       });
     }
+    maybeGrantTruthSense();
   const isDebug = ['localhost', '127.0.0.1'].includes(location.hostname) ||
     new URLSearchParams(location.search).has('debug');
 

--- a/manipulations.js
+++ b/manipulations.js
@@ -55,6 +55,7 @@ function showManipulation(id, cb) {
     manipulationLog.push({ room: event.id, tactic: event.type, outcome: 'resisted' });
     document.body.classList.remove('manipulation-mode');
     maybeGrantAnchor();
+    maybeGrantTruthSense();
     if (!skills.patternSense) {
       skills.patternSense = true;
       showSkillUnlock("Skill Unlocked: Pattern Sense");
@@ -119,6 +120,7 @@ function renderManipulationRoom(room) {
     playerPath.push(room.id);
     playerJourney.push({ roomId: room.id, choiceText: r.textContent, emotionSnapshot: dominantEmotion() });
     maybeGrantAnchor();
+    maybeGrantTruthSense();
     if (!skills.patternSense) {
       skills.patternSense = true;
       showSkillUnlock("Skill Unlocked: Pattern Sense");

--- a/state.js
+++ b/state.js
@@ -19,7 +19,9 @@ let skills = {
   patternSenseUses: 0,
   anchor: 0,
   anchorUnlocked: false,
-  anchorUses: 0
+  anchorUses: 0,
+  truthSense: false,
+  truthSenseTriggers: 0
 };
 let mazeCorruption = 0;
 let debugPanel = null;
@@ -205,6 +207,16 @@ function maybeGrantAnchor() {
   }
 }
 
+function maybeGrantTruthSense() {
+  if (skills.truthSense) return;
+  const loops = runHistory.length;
+  const survived = manipulationLog.filter(m => m.outcome !== 'submitted').length;
+  if (loops >= 2 || survived >= 4) {
+    skills.truthSense = true;
+    showSkillUnlock('Skill Unlocked: Truth Sense');
+  }
+}
+
 
 function showFlashback(text) {
   const box = document.getElementById('flashback-box');
@@ -316,6 +328,12 @@ function openSkills() {
     name: 'Emotional Anchor',
     uses: skills.anchorUses || 0,
     desc: 'Ground yourself in self-trust to resist manipulation.'
+  });
+  entries.push({
+    unlocked: skills.truthSense,
+    name: 'Truth Sense',
+    uses: skills.truthSenseTriggers || 0,
+    desc: 'Automatically detect false memories and distorted rooms.'
   });
   entries.forEach(e => {
     const div = document.createElement('div');

--- a/summary.html
+++ b/summary.html
@@ -105,6 +105,11 @@
       ap.textContent = `Skill unlocked: Emotional Anchor - used ${skills.anchorUses || 0} times`;
       document.getElementById("summary").appendChild(ap);
     }
+    if (skills.truthSense) {
+      const tp = document.createElement("p");
+      tp.textContent = `Skill unlocked: Truth Sense - triggered ${skills.truthSenseTriggers || 0} times`;
+      document.getElementById("summary").appendChild(tp);
+    }
 
     const journey = JSON.parse(localStorage.getItem('playerJourney') || '[]');
     archiveCurrentRun();


### PR DESCRIPTION
## Summary
- introduce **Truth Sense** skill
- reject distortions when Truth Sense triggers
- allow unlocking Truth Sense after repeated loops or manipulations
- surface Truth Sense info on the Skills screen and summary page
- document new skill in README

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6848d4283b5c8331a8c79f2dd3dc38e3