### PR TITLE
Add Null Final Path and dynamic true ending

### DIFF
--- a/game.js
+++ b/game.js
@@ -45,7 +45,18 @@ function renderRoom(roomId) {
   room.className = 'room';
 
   const p = document.createElement('p');
-  p.textContent = roomData.prompt;
+  const promptState = {
+    playerPath,
+    emotions,
+    triggeredFlashbacks,
+    manipulationLog,
+    skills
+  };
+  const promptText =
+    typeof roomData.prompt === 'function'
+      ? roomData.prompt(promptState)
+      : roomData.prompt;
+  p.textContent = promptText;
   room.appendChild(p);
 
   const available = roomData.choices.filter(ch => {

--- a/maze-data.js
+++ b/maze-data.js
@@ -109,8 +109,28 @@ const MAZE = {
   },
   null_pass: {
     id: "null_pass",
-    prompt: "The gate dissolves, leaving only clarity. You move forward." ,
-    choices: [ { text: "Step through", next: "ending_d", effects: { hope: 1 } } ]
+    prompt: "The gate dissolves, leaving only clarity. You move forward.",
+    choices: [ { text: "Step through", next: "null_path_1", effects: { hope: 1 } } ]
+  },
+  null_path_1: {
+    id: "null_path_1",
+    prompt: (s) => {
+      const resisted = (s.manipulationLog || []).filter(m => m.outcome === 'resisted' || m.outcome === 'anchored').length;
+      const submitted = (s.manipulationLog || []).filter(m => m.outcome === 'submitted').length;
+      const memories = (s.triggeredFlashbacks || []).length;
+      return `Mirrors reveal ${resisted} defiances and ${submitted} submissions. Memories recalled: ${memories}.`;
+    },
+    choices: [ { text: "Continue", next: "null_path_2" } ]
+  },
+  null_path_2: {
+    id: "null_path_2",
+    prompt: "Faces of your journey watch silently, awaiting acknowledgement.",
+    choices: [ { text: "Breathe", next: "null_end" } ]
+  },
+  null_end: {
+    id: "null_end",
+    prompt: "A final mirror shows your reflection whole. You step through and the maze fades behind you. End.",
+    choices: []
   },
   null_fail: {
     id: "null_fail",
@@ -227,6 +247,16 @@ const manipulationEncounters = [
 
 // Possible epilogue endings evaluated at the summary screen
 const endings = [
+  {
+    id: "ending_null_true",
+    condition: (state) => state.playerJourney.some((s) => s.roomId === 'null_end'),
+    text: (state) => {
+      const resisted = (state.manipulationLog || []).filter(m => m.outcome === 'resisted' || m.outcome === 'anchored').length;
+      const submitted = (state.manipulationLog || []).filter(m => m.outcome === 'submitted').length;
+      const memories = (state.triggeredFlashbacks || []).length;
+      return `You integrated every shadow and echo. Defiance: ${resisted}, Submission: ${submitted}, Memories reclaimed: ${memories}. With ${state.dominantEmotion || 'resolve'}, you leave the maze whole.`;
+    }
+  },
   {
     id: "ending_fear_shadow",
     condition: (state) =>

--- a/summary.html
+++ b/summary.html
@@ -136,13 +136,14 @@
       document.getElementById('summary').appendChild(hp);
     }
 
-    const state = { emotions, triggeredFlashbacks: flashbacks, playerJourney: journey };
+    const state = { emotions, triggeredFlashbacks: flashbacks, playerJourney: journey, manipulationLog: manip };
     state.dominantEmotion = dominant;
     const ending = getFinalEnding(state);
     const ep = document.getElementById('epilogue');
     const epClass = dominant ? `epilogue--${dominant}` : 'epilogue--neutral';
     ep.classList.add(epClass);
-    ep.innerHTML = `<p>${ending.text}</p>`;
+    const epText = typeof ending.text === 'function' ? ending.text(state) : ending.text;
+    ep.innerHTML = `<p>${epText}</p>`;
     const replay = document.createElement('button');
     replay.setAttribute('aria-label', 'Restart game');
     replay.textContent = 'Re-enter the Maze';


### PR DESCRIPTION
## Summary
- extend `renderRoom` to allow dynamic prompts with a game state
- redesign Null Gate path to unlock a hidden integration route
- add new `null_path_*` rooms culminating in `null_end`
- support dynamic epilogue text in `summary.html`
- introduce `ending_null_true` that resolves the player's journey

## Testing
- `node -c game.js`
- `node -c maze-data.js`
- `node -c summary.html` *(fails: ERR_UNKNOWN_FILE_EXTENSION)*

------
https://chatgpt.com/codex/tasks/task_e_6848d8fde19c8331b6d25cf215ea61da